### PR TITLE
Corrección de formato y prueba para número fuera de rango

### DIFF
--- a/nal.Test/NalControllerTest.cs
+++ b/nal.Test/NalControllerTest.cs
@@ -34,6 +34,16 @@ namespace nal.Test
         }
 
         [Fact]
+        public void Get_Numero_RespuestaFueraDeRango()
+        {
+            var fueraDeRango = new { letras = "Número fuera de rango." };
+
+            var respuesta = controller.Get(12345678901234567) as OkObjectResult;
+            
+            Assert.Equal(JsonConvert.SerializeObject(fueraDeRango), JsonConvert.SerializeObject(respuesta.Value));
+        }
+
+        [Fact]
         public void GetQuery_RespuestaOk()
         {
             var respuesta = controller.GetQuery(256);

--- a/nal.Test/NumerosALetrasTest.cs
+++ b/nal.Test/NumerosALetrasTest.cs
@@ -150,8 +150,17 @@ namespace nal.Test
             respuesta = NumerosALetras.ConvertirNumerosALetras("1256000");
             Assert.Equal("UN MILLÓN DOSCIENTOS CINCUENTA Y SEIS MIL", respuesta);
 
+            respuesta = NumerosALetras.ConvertirNumerosALetras("5000500");
+            Assert.Equal("CINCO MILLONES QUINIENTOS", respuesta);
+
+            respuesta = NumerosALetras.ConvertirNumerosALetras("1000000000000");
+            Assert.Equal("UN BILLÓN", respuesta);
+
             respuesta = NumerosALetras.ConvertirNumerosALetras("1000000256000");
             Assert.Equal("UN BILLÓN DOSCIENTOS CINCUENTA Y SEIS MIL", respuesta);
+
+            respuesta = NumerosALetras.ConvertirNumerosALetras("5000000000000");
+            Assert.Equal("CINCO BILLONES", respuesta);
         }
 
         [Fact]

--- a/nal/Controllers/NalController.cs
+++ b/nal/Controllers/NalController.cs
@@ -13,7 +13,7 @@ namespace nal.Controllers
         {
             if (!ModelState.IsValid) return BadRequest("No es un número.");
 
-            return Ok(new { letras = NumerosALetras.ConvertirNumerosALetras(num.ToString()) });
+            return Ok(new { letras = NumerosALetras.ConvertirNumerosALetras(num.ToString("G17"))});
         }
 
         // GET api/NAL?num=256
@@ -22,7 +22,7 @@ namespace nal.Controllers
         {
             if (!ModelState.IsValid) return BadRequest("No es un número.");
 
-            return Ok(new { letras = NumerosALetras.ConvertirNumerosALetras(num.ToString()) });
+            return Ok(new { letras = NumerosALetras.ConvertirNumerosALetras(num.ToString("G17"))});
         }
     }
 }

--- a/nal/Program.cs
+++ b/nal/Program.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using System.Diagnostics.CodeAnalysis;
 
 namespace nal
 {
+    [ExcludeFromCodeCoverage]
     public class Program
     {
         public static void Main(string[] args)

--- a/nal/Startup.cs
+++ b/nal/Startup.cs
@@ -5,9 +5,11 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using nal.Config;
 using Swashbuckle.AspNetCore.Swagger;
+using System.Diagnostics.CodeAnalysis;
 
 namespace nal
 {
+    [ExcludeFromCodeCoverage]
     public class Startup
     {
         public Startup(IConfiguration configuration)


### PR DESCRIPTION
Fixes #36.
- Corregir el formato de conversión a string para soportar números de hasta 16 dígitos.
- Retorna mensaje de error "Número fuera de rango." para números mayores a 16 dígitos.
- Agregar prueba de controlador para número fuera de rango.
- Excluir `Program.cs` y `Startup.cs` de cobertura.