### PR TITLE
Actualizar número de dígitos en README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ El API está publicada en el marketplace de **RapidAPI** en el siguiente enlace 
 
 Prueba -> https://nal.azurewebsites.net/api/NAL/256/
 
-*Actualmente el proyecto únicamente acepta cifras de hasta 19 dígitos y acepta hasta 2 decimales.*
+*Actualmente el proyecto únicamente acepta cifras de hasta 16 dígitos y acepta hasta 2 decimales.*


### PR DESCRIPTION
Fixes #46 
Actualizar número de dígitos en README a 16 ya que el número actual es incorrecto.