### PR TITLE
Habilitar lectura de comentarios XML en Swagger

### DIFF
--- a/nal/Controllers/NalController.cs
+++ b/nal/Controllers/NalController.cs
@@ -5,9 +5,13 @@ using nal.Classes;
 namespace nal.Controllers
 {
     [Route("api/[controller]")]
+    [ProducesResponseType(200)]
+    [ProducesResponseType(400)]
     public class NalController : Controller
-    {
-        // GET api/NAL?num=256
+    {        
+        /// <summary>
+        ///  Convierte un número de hasta 16 dígitos a letra.
+        /// </summary>
         [HttpGet]
         public ActionResult Get(double num)
         {

--- a/nal/Startup.cs
+++ b/nal/Startup.cs
@@ -7,6 +7,8 @@ using nal.Config;
 using Swashbuckle.AspNetCore.Swagger;
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Reflection;
 
 namespace nal
 {
@@ -41,6 +43,11 @@ namespace nal
                         Url = "https://epcon.com.mx/",
                     }
                 });
+
+                // Set the comments path for the Swagger JSON and UI.
+                var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+                var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
+                c.IncludeXmlComments(xmlPath);
             });
         }
         

--- a/nal/nal.csproj
+++ b/nal/nal.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Habilitar lectura de comentarios XML para ofrecer mayor claridad en documentación de API.